### PR TITLE
[Bug Report]: Patch for CVE-2018-9988 in reused component mbedtls-2.6.0 found by V1SCAN

### DIFF
--- a/Huawei_LiteOS/components/security/mbedtls/mbedtls-2.6.0/library/ssl_cli.c
+++ b/Huawei_LiteOS/components/security/mbedtls/mbedtls-2.6.0/library/ssl_cli.c
@@ -2473,14 +2473,13 @@ static int ssl_parse_server_key_exchange( mbedtls_ssl_context *ssl )
         sig_len = ( p[0] << 8 ) | p[1];
         p += 2;
 
-        if( end != p + sig_len )
+        if( p != end - sig_len )
         {
             MBEDTLS_SSL_DEBUG_MSG( 1, ( "bad server key exchange message" ) );
             mbedtls_ssl_send_alert_message( ssl, MBEDTLS_SSL_ALERT_LEVEL_FATAL,
                                             MBEDTLS_SSL_ALERT_MSG_DECODE_ERROR );
             return( MBEDTLS_ERR_SSL_BAD_HS_SERVER_KEY_EXCHANGE );
         }
-
         MBEDTLS_SSL_DEBUG_BUF( 3, "signature", p, sig_len );
 
         /*


### PR DESCRIPTION
Contact Details
weitingcai2020@gmail.com

What happened?
我通过使用V1SCAN（一个扫描存在于复用代码中1-Day漏洞的工具），发现您的项目中`Huawei_LiteOS/components/security/mbedtls/mbedtls-2.6.0/library/ssl_cli.c`文件中的`ssl_parse_server_key_exchange`函数可能存在类型为CWE-125 OOB的漏洞，相关触发逻辑类似https://github.com/advisories/GHSA-h9j8-4v77-hmr3, 具体参考链接如下：

CVE-2018-9988:
NVD说明链接：
https://nvd.nist.gov/vuln/detail/CVE-2018-9988
commit修复链接:
https://github.com/Mbed-TLS/mbedtls/commit/027f84c69f4ef30c0693832a6c396ef19e563ca1


